### PR TITLE
check_output() switched to Popen() for python 2.6 and above

### DIFF
--- a/pyexifinfo/pyexifinfo.py
+++ b/pyexifinfo/pyexifinfo.py
@@ -54,8 +54,11 @@ def command_line(cmd):
     or a string for the command line output
     """
     try:
-        s = subprocess.check_output(cmd)
+        s = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        s = s.stdout.read()
+        
         return s.strip()
+
     except subprocess.CalledProcessError:
         return 0
 


### PR DESCRIPTION
subprocess.check_output() does not work for < python 2.7. subprocess.popen() works on both 2.7 and 2.6.
